### PR TITLE
Dice roll system feasibility study

### DIFF
--- a/src/DiceTest.tsx
+++ b/src/DiceTest.tsx
@@ -7,7 +7,7 @@ export function DiceTest() {
   const [result, setResult] = useState<DiceResult | null>(null);
   const [lastMinuteDialog, setLastMinuteDialog] = useState<{
     isOpen: boolean;
-    variables: string[];
+    variables: Array<{name: string, defaultValue?: number}>;
   }>({ isOpen: false, variables: [] });
 
   const [variables, setVariables] = useState<Record<string, number>>({

--- a/src/DiceTest.tsx
+++ b/src/DiceTest.tsx
@@ -7,7 +7,7 @@ export function DiceTest() {
   const [result, setResult] = useState<DiceResult | null>(null);
   const [lastMinuteDialog, setLastMinuteDialog] = useState<{
     isOpen: boolean;
-    variables: Array<{name: string, defaultValue?: number}>;
+    variables: Array<{name: string, label?: string, defaultValue?: number}>;
   }>({ isOpen: false, variables: [] });
 
   const [variables, setVariables] = useState<Record<string, number>>({

--- a/src/DiceTest.tsx
+++ b/src/DiceTest.tsx
@@ -106,6 +106,8 @@ export function DiceTest() {
               if (roll.dropped) display += '(dropped)';
               if (roll.rerolled) display += '(rerolled)';
               if (roll.success) display += '✓';
+              if (roll.critical) display += '*';
+              if (roll.fumble) display += '**';
               return display;
             }).join(', ')}
           ]</p>
@@ -251,6 +253,22 @@ export function DiceTest() {
             marginTop: '10px'
           }}>
             {DICE_EXAMPLES.special.map((expr) => (
+              <button key={expr} onClick={() => testExpression(expr)} style={buttonStyle}>
+                {expr}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <h4>Crit/Fumble System:</h4>
+          <div style={{ 
+            display: 'flex', 
+            flexWrap: 'wrap', 
+            gap: '8px',
+            marginTop: '10px'
+          }}>
+            {DICE_EXAMPLES.critfumble.map((expr) => (
               <button key={expr} onClick={() => testExpression(expr)} style={buttonStyle}>
                 {expr}
               </button>

--- a/src/DiceTest.tsx
+++ b/src/DiceTest.tsx
@@ -1,9 +1,14 @@
 import { useState } from 'react';
 import { rollDice, DICE_EXAMPLES, type DiceResult } from './dice-main';
+import { LastMinuteDialog } from './components/LastMinuteDialog';
 
 export function DiceTest() {
   const [expression, setExpression] = useState('2d6');
   const [result, setResult] = useState<DiceResult | null>(null);
+  const [lastMinuteDialog, setLastMinuteDialog] = useState<{
+    isOpen: boolean;
+    variables: string[];
+  }>({ isOpen: false, variables: [] });
 
   const [variables, setVariables] = useState<Record<string, number>>({
     STR: 3,
@@ -18,13 +23,39 @@ export function DiceTest() {
 
   const handleRoll = () => {
     const rollResult = rollDice(expression, variables);
+    
+    if (rollResult.needsLastMinuteVars) {
+      setLastMinuteDialog({
+        isOpen: true,
+        variables: rollResult.needsLastMinuteVars
+      });
+    } else {
+      setResult(rollResult);
+    }
+  };
+
+  const handleLastMinuteConfirm = (lastMinuteValues: Record<string, number>) => {
+    const rollResult = rollDice(expression, variables, lastMinuteValues);
     setResult(rollResult);
+    setLastMinuteDialog({ isOpen: false, variables: [] });
+  };
+
+  const handleLastMinuteCancel = () => {
+    setLastMinuteDialog({ isOpen: false, variables: [] });
   };
 
   const testExpression = (expr: string) => {
     setExpression(expr);
     const rollResult = rollDice(expr, variables);
-    setResult(rollResult);
+    
+    if (rollResult.needsLastMinuteVars) {
+      setLastMinuteDialog({
+        isOpen: true,
+        variables: rollResult.needsLastMinuteVars
+      });
+    } else {
+      setResult(rollResult);
+    }
   };
 
   const buttonStyle = {
@@ -275,7 +306,31 @@ export function DiceTest() {
             ))}
           </div>
         </div>
+
+        <div style={{ marginBottom: '20px' }}>
+          <h4>Last Minute Variables:</h4>
+          <div style={{ 
+            display: 'flex', 
+            flexWrap: 'wrap', 
+            gap: '8px',
+            marginTop: '10px'
+          }}>
+            {DICE_EXAMPLES.lastminute.map((expr) => (
+              <button key={expr} onClick={() => testExpression(expr)} style={buttonStyle}>
+                {expr}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
+
+      {/* Last Minute Variables Dialog */}
+      <LastMinuteDialog
+        variables={lastMinuteDialog.variables}
+        onConfirm={handleLastMinuteConfirm}
+        onCancel={handleLastMinuteCancel}
+        isOpen={lastMinuteDialog.isOpen}
+      />
     </div>
   );
 }

--- a/src/components/LastMinuteDialog.tsx
+++ b/src/components/LastMinuteDialog.tsx
@@ -86,16 +86,6 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
                   color: '#374151'
                 }}>
                   {variable.name}:
-                  {variable.defaultValue !== undefined && (
-                    <span style={{
-                      fontSize: '12px',
-                      fontWeight: 'normal',
-                      color: '#6b7280',
-                      marginLeft: '8px'
-                    }}>
-                      (default: {variable.defaultValue})
-                    </span>
-                  )}
                 </label>
                 <input
                   type="number"

--- a/src/components/LastMinuteDialog.tsx
+++ b/src/components/LastMinuteDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 interface LastMinuteDialogProps {
-  variables: Array<{name: string, defaultValue?: number}>;
+  variables: Array<{name: string, label?: string, defaultValue?: number}>;
   onConfirm: (values: Record<string, number>) => void;
   onCancel: () => void;
   isOpen: boolean;
@@ -85,7 +85,7 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
                   marginBottom: '5px',
                   color: '#374151'
                 }}>
-                  {variable.name}:
+                  {variable.label ? variable.label.replace(/_/g, ' ') : variable.name}:
                 </label>
                 <input
                   type="number"

--- a/src/components/LastMinuteDialog.tsx
+++ b/src/components/LastMinuteDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 interface LastMinuteDialogProps {
-  variables: string[];
+  variables: Array<{name: string, defaultValue?: number}>;
   onConfirm: (values: Record<string, number>) => void;
   onCancel: () => void;
   isOpen: boolean;
@@ -12,10 +12,10 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
 
   useEffect(() => {
     if (isOpen) {
-      // Initialize values with 0
+      // Initialize values with defaults or 0
       const initialValues: Record<string, number> = {};
       variables.forEach(variable => {
-        initialValues[variable] = 0;
+        initialValues[variable.name] = variable.defaultValue || 0;
       });
       setValues(initialValues);
     }
@@ -26,10 +26,10 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
     onConfirm(values);
   };
 
-  const handleValueChange = (variable: string, value: string) => {
+  const handleValueChange = (variableName: string, value: string) => {
     setValues(prev => ({
       ...prev,
-      [variable]: parseInt(value) || 0
+      [variableName]: parseInt(value) || 0
     }));
   };
 
@@ -77,7 +77,7 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
         <form onSubmit={handleSubmit}>
           <div style={{ marginBottom: '20px' }}>
             {variables.map(variable => (
-              <div key={variable} style={{ marginBottom: '15px' }}>
+              <div key={variable.name} style={{ marginBottom: '15px' }}>
                 <label style={{
                   display: 'block',
                   fontSize: '16px',
@@ -85,12 +85,22 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
                   marginBottom: '5px',
                   color: '#374151'
                 }}>
-                  {variable}:
+                  {variable.name}:
+                  {variable.defaultValue !== undefined && (
+                    <span style={{
+                      fontSize: '12px',
+                      fontWeight: 'normal',
+                      color: '#6b7280',
+                      marginLeft: '8px'
+                    }}>
+                      (default: {variable.defaultValue})
+                    </span>
+                  )}
                 </label>
                 <input
                   type="number"
-                  value={values[variable] || 0}
-                  onChange={(e) => handleValueChange(variable, e.target.value)}
+                  value={values[variable.name] || 0}
+                  onChange={(e) => handleValueChange(variable.name, e.target.value)}
                   style={{
                     width: '100%',
                     padding: '12px',
@@ -100,7 +110,7 @@ export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: Las
                     minHeight: '44px',
                     boxSizing: 'border-box'
                   }}
-                  autoFocus={variable === variables[0]}
+                  autoFocus={variable.name === variables[0]?.name}
                 />
               </div>
             ))}

--- a/src/components/LastMinuteDialog.tsx
+++ b/src/components/LastMinuteDialog.tsx
@@ -1,0 +1,150 @@
+import { useState, useEffect } from 'react';
+
+interface LastMinuteDialogProps {
+  variables: string[];
+  onConfirm: (values: Record<string, number>) => void;
+  onCancel: () => void;
+  isOpen: boolean;
+}
+
+export function LastMinuteDialog({ variables, onConfirm, onCancel, isOpen }: LastMinuteDialogProps) {
+  const [values, setValues] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    if (isOpen) {
+      // Initialize values with 0
+      const initialValues: Record<string, number> = {};
+      variables.forEach(variable => {
+        initialValues[variable] = 0;
+      });
+      setValues(initialValues);
+    }
+  }, [isOpen, variables]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onConfirm(values);
+  };
+
+  const handleValueChange = (variable: string, value: string) => {
+    setValues(prev => ({
+      ...prev,
+      [variable]: parseInt(value) || 0
+    }));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000
+    }}>
+      <div style={{
+        backgroundColor: 'white',
+        padding: '30px',
+        borderRadius: '12px',
+        boxShadow: '0 10px 30px rgba(0, 0, 0, 0.3)',
+        maxWidth: '400px',
+        width: '90%',
+        maxHeight: '80vh',
+        overflow: 'auto'
+      }}>
+        <h2 style={{
+          margin: '0 0 20px 0',
+          color: '#333',
+          fontSize: '1.5rem'
+        }}>
+          🎲 Last Minute Variables
+        </h2>
+        
+        <p style={{
+          margin: '0 0 20px 0',
+          color: '#666',
+          fontSize: '14px'
+        }}>
+          Enter values for the following variables:
+        </p>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '20px' }}>
+            {variables.map(variable => (
+              <div key={variable} style={{ marginBottom: '15px' }}>
+                <label style={{
+                  display: 'block',
+                  fontSize: '16px',
+                  fontWeight: 'bold',
+                  marginBottom: '5px',
+                  color: '#374151'
+                }}>
+                  {variable}:
+                </label>
+                <input
+                  type="number"
+                  value={values[variable] || 0}
+                  onChange={(e) => handleValueChange(variable, e.target.value)}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    border: '2px solid #e5e7eb',
+                    borderRadius: '8px',
+                    fontSize: '16px',
+                    minHeight: '44px',
+                    boxSizing: 'border-box'
+                  }}
+                  autoFocus={variable === variables[0]}
+                />
+              </div>
+            ))}
+          </div>
+
+          <div style={{
+            display: 'flex',
+            gap: '10px',
+            justifyContent: 'flex-end'
+          }}>
+            <button
+              type="button"
+              onClick={onCancel}
+              style={{
+                padding: '12px 20px',
+                backgroundColor: '#6b7280',
+                color: 'white',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                fontSize: '16px',
+                minHeight: '44px'
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              style={{
+                padding: '12px 20px',
+                backgroundColor: '#4CAF50',
+                color: 'white',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                fontSize: '16px',
+                minHeight: '44px'
+              }}
+            >
+              🎲 Roll Dice
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/dice-engine.ts
+++ b/src/dice-engine.ts
@@ -166,6 +166,11 @@ export class DiceTokenizer {
     } else if (this.current === '!') {
       result += this.current;
       this.advance();
+    } else if (this.current === 'c' || this.current === 'f') {
+      // Handle crit (c1) and fumble (f12) modifiers
+      result += this.current;
+      this.advance();
+      // The number will be parsed separately
     }
     
     return result;
@@ -241,7 +246,7 @@ export class DiceTokenizer {
         const value = this.readComparison();
         tokens.push({ type: TokenType.COMPARISON, value, position: startPos });
       }
-      else if (this.current === 'k' || this.current === 'r' || this.current === '!') {
+      else if (this.current === 'k' || this.current === 'r' || this.current === '!' || this.current === 'c' || this.current === 'f') {
         const value = this.readModifier();
         tokens.push({ type: TokenType.MODIFIER, value, position: startPos });
       }
@@ -385,6 +390,26 @@ export class DiceParser {
               type: 'reroll',
               operator: roCondition as '>=' | '>' | '=' | '<=' | '<',
               value: roValue
+            });
+            break;
+            
+          case 'c':
+            // Critical success modifier (c1, c20, etc.)
+            const critValue = this.current().type === TokenType.NUMBER ? 
+              this.parseNumber().value : 1; // Default to 1
+            modifiers.push({
+              type: 'crit',
+              critValue: critValue
+            });
+            break;
+            
+          case 'f':
+            // Fumble modifier (f12, f1, etc.)
+            const fumbleValue = this.current().type === TokenType.NUMBER ? 
+              this.parseNumber().value : 12; // Default to 12
+            modifiers.push({
+              type: 'fumble',
+              fumbleValue: fumbleValue
             });
             break;
         }

--- a/src/dice-evaluator.ts
+++ b/src/dice-evaluator.ts
@@ -174,6 +174,30 @@ export class DiceEvaluator {
           }
         }
       }
+      
+      // Step 5: Apply critical successes and fumbles
+      const critMod = modifiers.find(m => m.type === 'crit');
+      const fumbleMod = modifiers.find(m => m.type === 'fumble');
+      
+      if (critMod) {
+        const critValue = critMod.critValue || 1;
+        for (const roll of workingRolls) {
+          if (!roll.dropped && !roll.rerolled && roll.result === critValue) {
+            roll.critical = true;
+            successes++; // +1 for critical success
+          }
+        }
+      }
+      
+      if (fumbleMod) {
+        const fumbleValue = fumbleMod.fumbleValue || 12;
+        for (const roll of workingRolls) {
+          if (!roll.dropped && !roll.rerolled && roll.result === fumbleValue) {
+            roll.fumble = true;
+            successes--; // -1 for fumble
+          }
+        }
+      }
     }
 
     return { finalRolls: workingRolls, successes };
@@ -396,6 +420,8 @@ export class DiceEvaluator {
             let str = r.result.toString();
             if (r.exploded) str += '!';
             if (r.success) str += '✓';
+            if (r.critical) str += '*';
+            if (r.fumble) str += '**';
             return str;
           });
           part += ` (${results.join(', ')})`;
@@ -403,6 +429,8 @@ export class DiceEvaluator {
           let str = activeRolls[0].result.toString();
           if (activeRolls[0].exploded) str += '!';
           if (activeRolls[0].success) str += '✓';
+          if (activeRolls[0].critical) str += '*';
+          if (activeRolls[0].fumble) str += '**';
           part += ` (${str})`;
         }
         

--- a/src/dice-main.ts
+++ b/src/dice-main.ts
@@ -35,17 +35,18 @@ function compareRoll(roll: number, operator: string, target: number): boolean {
   }
 }
 
-export function extractLastMinuteVariables(expression: string): Array<{name: string, defaultValue?: number}> {
-  const matches = expression.match(/\(\?([A-Z_][A-Z0-9_]*)(?:=(\d+))?\)/g);
+export function extractLastMinuteVariables(expression: string): Array<{name: string, label?: string, defaultValue?: number}> {
+  const matches = expression.match(/\(\?([A-Z_][A-Z0-9_]*)(?:\|([A-Z_][A-Z0-9_]*))?(?:=(\d+))?\)/g);
   if (!matches) return [];
   
   return matches.map(match => {
-    const nameMatch = match.match(/\(\?([A-Z_][A-Z0-9_]*)(?:=(\d+))?\)/);
-    if (!nameMatch) return { name: '', defaultValue: undefined };
+    const nameMatch = match.match(/\(\?([A-Z_][A-Z0-9_]*)(?:\|([A-Z_][A-Z0-9_]*))?(?:=(\d+))?\)/);
+    if (!nameMatch) return { name: '', label: undefined, defaultValue: undefined };
     
     const name = nameMatch[1];
-    const defaultValue = nameMatch[2] ? parseInt(nameMatch[2]) : undefined;
-    return { name, defaultValue };
+    const label = nameMatch[2] || undefined;
+    const defaultValue = nameMatch[3] ? parseInt(nameMatch[3]) : undefined;
+    return { name, label, defaultValue };
   });
 }
 
@@ -73,7 +74,7 @@ export function rollDice(expression: string, variables: Record<string, number> =
     // Replace last minute variables if provided
     if (lastMinuteVars) {
       for (const [name, value] of Object.entries(lastMinuteVars)) {
-        const regex = new RegExp(`\\(\\?${name.toLowerCase()}(?:=\\d+)?\\)`, 'g');
+        const regex = new RegExp(`\\(\\?${name.toLowerCase()}(?:\\|[^|)]+)?(?:=\\d+)?\\)`, 'g');
         if (expr.includes(`(?${name.toLowerCase()}`)) {
           expr = expr.replace(regex, value.toString());
           usedVariables[name] = value;

--- a/src/dice-main.ts
+++ b/src/dice-main.ts
@@ -35,11 +35,18 @@ function compareRoll(roll: number, operator: string, target: number): boolean {
   }
 }
 
-export function extractLastMinuteVariables(expression: string): string[] {
-  const matches = expression.match(/\(\?([A-Z_][A-Z0-9_]*)\)/g);
+export function extractLastMinuteVariables(expression: string): Array<{name: string, defaultValue?: number}> {
+  const matches = expression.match(/\(\?([A-Z_][A-Z0-9_]*)(?:=(\d+))?\)/g);
   if (!matches) return [];
   
-  return matches.map(match => match.slice(2, -1)); // Remove (? and )
+  return matches.map(match => {
+    const nameMatch = match.match(/\(\?([A-Z_][A-Z0-9_]*)(?:=(\d+))?\)/);
+    if (!nameMatch) return { name: '', defaultValue: undefined };
+    
+    const name = nameMatch[1];
+    const defaultValue = nameMatch[2] ? parseInt(nameMatch[2]) : undefined;
+    return { name, defaultValue };
+  });
 }
 
 /**
@@ -50,13 +57,13 @@ export function rollDice(expression: string, variables: Record<string, number> =
     let expr = expression.toLowerCase().trim();
     const usedVariables: Record<string, number> = {};
     
-    // Check for last minute variables (?NAME)
+    // Check for last minute variables (?NAME or ?NAME=DEFAULT)
     const requiredLastMinuteVars = extractLastMinuteVariables(expr);
     if (requiredLastMinuteVars.length > 0 && !lastMinuteVars) {
       return {
         expression,
         total: 0,
-        breakdown: `Needs last minute variables: ${requiredLastMinuteVars.join(', ')}`,
+        breakdown: `Needs last minute variables: ${requiredLastMinuteVars.map(v => v.name).join(', ')}`,
         rolls: [],
         needsLastMinuteVars: requiredLastMinuteVars,
         variables: usedVariables
@@ -66,8 +73,8 @@ export function rollDice(expression: string, variables: Record<string, number> =
     // Replace last minute variables if provided
     if (lastMinuteVars) {
       for (const [name, value] of Object.entries(lastMinuteVars)) {
-        const regex = new RegExp(`\\(\\?${name.toLowerCase()}\\)`, 'g');
-        if (expr.includes(`(?${name.toLowerCase()})`)) {
+        const regex = new RegExp(`\\(\\?${name.toLowerCase()}(?:=\\d+)?\\)`, 'g');
+        if (expr.includes(`(?${name.toLowerCase()}`)) {
           expr = expr.replace(regex, value.toString());
           usedVariables[name] = value;
         }

--- a/src/dice-main.ts
+++ b/src/dice-main.ts
@@ -35,13 +35,44 @@ function compareRoll(roll: number, operator: string, target: number): boolean {
   }
 }
 
+export function extractLastMinuteVariables(expression: string): string[] {
+  const matches = expression.match(/\(\?([A-Z_][A-Z0-9_]*)\)/g);
+  if (!matches) return [];
+  
+  return matches.map(match => match.slice(2, -1)); // Remove (? and )
+}
+
 /**
  * Main dice rolling function with universal notation support
  */
-export function rollDice(expression: string, variables: Record<string, number> = {}): DiceResult {
+export function rollDice(expression: string, variables: Record<string, number> = {}, lastMinuteVars?: Record<string, number>): DiceResult {
   try {
     let expr = expression.toLowerCase().trim();
     const usedVariables: Record<string, number> = {};
+    
+    // Check for last minute variables (?NAME)
+    const requiredLastMinuteVars = extractLastMinuteVariables(expr);
+    if (requiredLastMinuteVars.length > 0 && !lastMinuteVars) {
+      return {
+        expression,
+        total: 0,
+        breakdown: `Needs last minute variables: ${requiredLastMinuteVars.join(', ')}`,
+        rolls: [],
+        needsLastMinuteVars: requiredLastMinuteVars,
+        variables: usedVariables
+      };
+    }
+    
+    // Replace last minute variables if provided
+    if (lastMinuteVars) {
+      for (const [name, value] of Object.entries(lastMinuteVars)) {
+        const regex = new RegExp(`\\(\\?${name.toLowerCase()}\\)`, 'g');
+        if (expr.includes(`(?${name.toLowerCase()})`)) {
+          expr = expr.replace(regex, value.toString());
+          usedVariables[name] = value;
+        }
+      }
+    }
     
     // Replace variables
     for (const [name, value] of Object.entries(variables)) {

--- a/src/dice-main.ts
+++ b/src/dice-main.ts
@@ -398,6 +398,30 @@ function applyModifiers(
         }
       }
     }
+    
+    // Handle critical successes and fumbles
+    const critMatch = modifiers.match(/c(\d+)/);
+    const fumbleMatch = modifiers.match(/f(\d+)/);
+    
+    if (critMatch) {
+      const critValue = parseInt(critMatch[1]);
+      for (const roll of workingRolls) {
+        if (!roll.dropped && !roll.rerolled && roll.result === critValue) {
+          roll.critical = true;
+          successCount++; // +1 for critical success
+        }
+      }
+    }
+    
+    if (fumbleMatch) {
+      const fumbleValue = parseInt(fumbleMatch[1]);
+      for (const roll of workingRolls) {
+        if (!roll.dropped && !roll.rerolled && roll.result === fumbleValue) {
+          roll.fumble = true;
+          successCount--; // -1 for fumble
+        }
+      }
+    }
   }
   
   // Calculate final value
@@ -421,6 +445,8 @@ function applyModifiers(
       let str = r.result.toString();
       if (r.exploded) str += '!';
       if (r.success) str += '✓';
+      if (r.critical) str += '*';
+      if (r.fumble) str += '**';
       return str;
     });
     breakdown += ` (${results.join(', ')})`;
@@ -428,6 +454,8 @@ function applyModifiers(
     let str = activeRolls[0].result.toString();
     if (activeRolls[0].exploded) str += '!';
     if (activeRolls[0].success) str += '✓';
+    if (activeRolls[0].critical) str += '*';
+    if (activeRolls[0].fumble) str += '**';
     breakdown += ` (${str})`;
   }
   

--- a/src/dice-types.ts
+++ b/src/dice-types.ts
@@ -27,7 +27,7 @@ export interface DiceResult {
   fear?: number;
   tag?: string;
   variables?: Record<string, number>;
-  needsLastMinuteVars?: Array<{name: string, defaultValue?: number}>;
+  needsLastMinuteVars?: Array<{name: string, label?: string, defaultValue?: number}>;
 }
 
 // AST Node types for advanced parsing
@@ -122,6 +122,10 @@ export const DICE_EXAMPLES = {
     '(?ATTRIB=12)d12>=(?SKILL=8)', 
     '(?BONUS=3)d6+5', 
     '(?DICE=6)d(?SIDES=12)>=(?TARGET=8)',
-    '(?COUNT=4)d12>=8 c1 f12'
+    '(?COUNT=4)d12>=8 c1 f12',
+    '(?ATTRIB|Attack_Defense)d12>=(?SKILL|Skill_Level)', 
+    '(?BONUS|Damage_Bonus=3)d6+5', 
+    '(?DICE|Dice_Count=6)d(?SIDES|Dice_Sides=12)>=(?TARGET|Target_Number=8)',
+    '(?SKILLED=1|Skill_Learned)d12>=8 c(?SKILLED)'
   ]
 };

--- a/src/dice-types.ts
+++ b/src/dice-types.ts
@@ -27,7 +27,7 @@ export interface DiceResult {
   fear?: number;
   tag?: string;
   variables?: Record<string, number>;
-  needsLastMinuteVars?: string[];
+  needsLastMinuteVars?: Array<{name: string, defaultValue?: number}>;
 }
 
 // AST Node types for advanced parsing
@@ -114,5 +114,14 @@ export const DICE_EXAMPLES = {
   daggerheart: ['dh', 'dh a2', 'dh d1', 'dh a2 d1'],
   special: ['4dF', 'adv', 'dis', '2d10!>=8'],
   critfumble: ['6d12>=8 c1', '6d12<=3 f12', '6d12>=6 c1 f12', '4d20>=15 c20 f1'],
-  lastminute: ['(?ATTRIB)d12>=(?SKILL)', '(?BONUS)d6+5', '(?DICE)d(?SIDES)>=(?TARGET)', '(?COUNT)d12>=8 c1 f12']
+  lastminute: [
+    '(?ATTRIB)d12>=(?SKILL)', 
+    '(?BONUS)d6+5', 
+    '(?DICE)d(?SIDES)>=(?TARGET)', 
+    '(?COUNT)d12>=8 c1 f12',
+    '(?ATTRIB=12)d12>=(?SKILL=8)', 
+    '(?BONUS=3)d6+5', 
+    '(?DICE=6)d(?SIDES=12)>=(?TARGET=8)',
+    '(?COUNT=4)d12>=8 c1 f12'
+  ]
 };

--- a/src/dice-types.ts
+++ b/src/dice-types.ts
@@ -8,6 +8,8 @@ export interface DiceRoll {
   dropped?: boolean;
   rerolled?: boolean;
   success?: boolean;
+  critical?: boolean;
+  fumble?: boolean;
 }
 
 export interface DiceResult {
@@ -71,11 +73,13 @@ export interface TargetNode extends ASTNode {
 }
 
 export interface DiceModifier {
-  type: 'keep' | 'drop' | 'explode' | 'reroll' | 'success';
+  type: 'keep' | 'drop' | 'explode' | 'reroll' | 'success' | 'crit' | 'fumble';
   variant?: 'high' | 'low' | 'once';
   value?: number | VariableNode;
   operator?: '>=' | '>' | '=' | '<=' | '<';
   limit?: number;
+  critValue?: number;
+  fumbleValue?: number;
 }
 
 // Token types for parsing
@@ -107,5 +111,6 @@ export const DICE_EXAMPLES = {
   basic: ['1d20', '2d6+3', '4d6kh3', '1d20+5'],
   advanced: ['2d20kh1', '2d20kl1', '4d6!', '6d6>=4', '3d6r1', '1d20+5 t>=15'],
   daggerheart: ['dh', 'dh a2', 'dh d1', 'dh a2 d1'],
-  special: ['4dF', 'adv', 'dis', '2d10!>=8']
+  special: ['4dF', 'adv', 'dis', '2d10!>=8'],
+  critfumble: ['6d12>=8 c1', '6d12<=3 f12', '6d12>=6 c1 f12', '4d20>=15 c20 f1']
 };

--- a/src/dice-types.ts
+++ b/src/dice-types.ts
@@ -27,6 +27,7 @@ export interface DiceResult {
   fear?: number;
   tag?: string;
   variables?: Record<string, number>;
+  needsLastMinuteVars?: string[];
 }
 
 // AST Node types for advanced parsing
@@ -112,5 +113,6 @@ export const DICE_EXAMPLES = {
   advanced: ['2d20kh1', '2d20kl1', '4d6!', '6d6>=4', '3d6r1', '1d20+5 t>=15'],
   daggerheart: ['dh', 'dh a2', 'dh d1', 'dh a2 d1'],
   special: ['4dF', 'adv', 'dis', '2d10!>=8'],
-  critfumble: ['6d12>=8 c1', '6d12<=3 f12', '6d12>=6 c1 f12', '4d20>=15 c20 f1']
+  critfumble: ['6d12>=8 c1', '6d12<=3 f12', '6d12>=6 c1 f12', '4d20>=15 c20 f1'],
+  lastminute: ['(?ATTRIB)d12>=(?SKILL)', '(?BONUS)d6+5', '(?DICE)d(?SIDES)>=(?TARGET)', '(?COUNT)d12>=8 c1 f12']
 };


### PR DESCRIPTION
Add `c<value>` and `f<value>` modifiers to support critical successes and fumbles in success-based dice rolls.

This implements a user-requested feature to allow specific dice results (e.g., 1s or 12s) to count as additional successes or subtract successes, respectively. This enhances the flexibility of the dice engine for various tabletop RPG mechanics, supporting both "low is good" and "high is good" systems with special outcomes.

---
<a href="https://cursor.com/background-agent?bcId=bc-29bf1b67-d946-4480-9eb9-9d545e73205b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29bf1b67-d946-4480-9eb9-9d545e73205b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

